### PR TITLE
By default the Docker run will make use of in-memory mount destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.7.1] - 2018-01-24
+### Fixed
+- Issue [#29](https://github.com/42BV/spring-boot-docker-postgres/issues/29), **By default use in-memory destination mounts for Docker run**; by default the Docker run will make use of in-memory mounts for the application and data path in the standard Postgres Docker image. If in-memory must be disabled, it can be done in the properties. Custom paths can be passed as a list under the inMemoryMountDestinations list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [0.7.1] - 2018-01-24
+## [0.7.1] - 2018-01-25
 ### Fixed
 - Issue [#29](https://github.com/42BV/spring-boot-docker-postgres/issues/29), **By default use in-memory destination mounts for Docker run**; by default the Docker run will make use of in-memory mounts for the application and data path in the standard Postgres Docker image. If in-memory must be disabled, it can be done in the properties. Custom paths can be passed as a list under the inMemoryMountDestinations list.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-boot-docker-postgres</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.7.1</version>
     <packaging>jar</packaging>
     <groupId>nl.42</groupId>
 

--- a/src/main/java/nl/_42/boot/docker/postgres/DockerPostgresProperties.java
+++ b/src/main/java/nl/_42/boot/docker/postgres/DockerPostgresProperties.java
@@ -1,12 +1,21 @@
 package nl._42.boot.docker.postgres;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @ConfigurationProperties(prefix = "docker.postgres", ignoreUnknownFields = false)
 public class DockerPostgresProperties {
+
+    private static final String DEFAULT_PORT                        = "5432";
+    private static final String POSTGRES_BASE_FOLDER_APPLICATION    = "/app";
+    private static final String POSTGRES_BASE_FOLDER_DATA           = "/var/lib/postgresql/data";
+    private static final String IN_MEMORY_TEMPLATE                  = "[IN_MEMORY_TEMPLATE]";
+    private static final String VAR_IN_MEMORY_MOUNT_DESTINATION     = "inMemoryMountDestination";
 
     private boolean enabled = true;
 
@@ -28,7 +37,9 @@ public class DockerPostgresProperties {
 
     private Integer timesExpectedVerificationText = 2;
 
-    private String dockerCommand = "docker run --rm --tty -e POSTGRES_PASSWORD=${password} -p ${port}:5432 --name ${containerName} ${imageName}:${imageVersion}";
+    private String dockerCommand = "docker run --rm --tty -e POSTGRES_PASSWORD=${password} -p ${port}:5432 --name ${containerName} " + IN_MEMORY_TEMPLATE + " ${imageName}:${imageVersion}";
+
+    private String useDockerCommand;
 
     private Integer timeout = 300000; // 5 minutes because of time required for downloading?
 
@@ -42,7 +53,21 @@ public class DockerPostgresProperties {
 
     private String containerOccupyingPort = null;
 
+    private boolean inMemory = true;
+
+    private String inMemoryMountDestinationCommand =
+            "--mount type=tmpfs,destination=${" + VAR_IN_MEMORY_MOUNT_DESTINATION + "_@N}";
+
+    private List<String> inMemoryMountDestinations = new ArrayList<>();
+
     private Map<String, String> customVariables = new HashMap<>();
+
+    Map<String,String> properties = null;
+
+    public DockerPostgresProperties() {
+        inMemoryMountDestinations.add(POSTGRES_BASE_FOLDER_APPLICATION);
+        inMemoryMountDestinations.add(POSTGRES_BASE_FOLDER_DATA);
+    }
 
     public boolean isEnabled() {
         return enabled;
@@ -188,8 +213,57 @@ public class DockerPostgresProperties {
         this.forceCleanAfterwards = forceCleanAfterwards;
     }
 
+    public boolean isInMemory() {
+        return inMemory;
+    }
+
+    public void setInMemory(boolean inMemory) {
+        this.inMemory = inMemory;
+    }
+
+    public List<String> getInMemoryMountDestinations() {
+        return inMemoryMountDestinations;
+    }
+
+    public void setInMemoryMountDestinations(List<String> inMemoryMountDestinations) {
+        this.inMemoryMountDestinations = inMemoryMountDestinations;
+    }
+
+    public String getInMemoryMountDestinationCommand() {
+        return inMemoryMountDestinationCommand;
+    }
+
+    public void setInMemoryMountDestinationCommand(String inMemoryMountDestinationCommand) {
+        this.inMemoryMountDestinationCommand = inMemoryMountDestinationCommand;
+    }
+
+    public String getUseDockerCommand() {
+        if (useDockerCommand == null) {
+            getProperties();
+        }
+        return useDockerCommand;
+    }
+
     public Map<String, String> getProperties() {
-        Map<String,String> properties = new HashMap<>();
+        return properties;
+    }
+
+    public void init(String datasourceUrl) {
+        initPort(datasourceUrl);
+        properties = new HashMap<>();
+        this.useDockerCommand = replaceInMemoryTemplate(properties, getDockerCommand());
+        initProperties();
+    }
+
+    private void initPort(String datasourceUrl) {
+        if (getPort() != null) {
+            return;
+        }
+        // Scrape the port from the JDBC URL
+        setPort(determinePort(datasourceUrl != null ? datasourceUrl : DEFAULT_PORT));
+    }
+
+    private void initProperties() {
         properties.put("stdOutFilename", getStdOutFilename());
         properties.put("stdErrFilename", getStdErrFilename());
         properties.put("timeout", getTimeout().toString());
@@ -202,13 +276,50 @@ public class DockerPostgresProperties {
         properties.put("timesExpectedVerificationText", getTimesExpectedVerificationText().toString());
         properties.put("afterVerificationWait", getAfterVerificationWait().toString());
         properties.put("dockerCommand", getDockerCommand());
+        properties.put("useDockerCommand", getUseDockerCommand());
         properties.put("forceClean", Boolean.toString(isForceClean()));
         properties.put("forceCleanAfterwards", Boolean.toString(isForceCleanAfterwards()));
         properties.put("stopPortOccupyingContainer", Boolean.toString(isStopPortOccupyingContainer()));
         properties.put("afterVerificationWait", Boolean.toString(isForceClean()));
         properties.put("containerOccupyingPort", getContainerOccupyingPort());
+        properties.put("inMemory", Boolean.toString(isInMemory()));
         properties.putAll(getCustomVariables());
-        return properties;
+    }
+
+    private String replaceInMemoryTemplate(Map<String, String> properties, String dockerCommand) {
+        int templatePosition = dockerCommand.indexOf(IN_MEMORY_TEMPLATE);
+        if (templatePosition == -1) {
+            return dockerCommand;
+        }
+        List<String> inMemoryCommands = new ArrayList<>();
+        if (inMemory) {
+            Integer destinationNumber = 1;
+            for (String inMemoryMountDestination : getInMemoryMountDestinations()) {
+                inMemoryCommands.add(inMemoryMountDestinationCommand.replace(
+                        "@N",
+                        destinationNumber.toString()));
+                properties.put(
+                        VAR_IN_MEMORY_MOUNT_DESTINATION + "_" + destinationNumber,
+                        inMemoryMountDestination);
+                destinationNumber++;
+            }
+        }
+        return
+                dockerCommand.substring(0, templatePosition) +
+                StringUtils.join(inMemoryCommands, ' ') +
+                dockerCommand.substring(templatePosition + IN_MEMORY_TEMPLATE.length());
+    }
+
+    private Integer determinePort(String url) {
+        if (url == null || url.length() == 0) {
+            throw new ExceptionInInitializerError("spring.datasource.url is empty. No port could be derived.");
+        }
+        int lastColonPos = url.lastIndexOf(':');
+        int slashAfterPortPos = url.indexOf('/', lastColonPos);
+        if (lastColonPos == -1 || slashAfterPortPos == -1 || slashAfterPortPos < lastColonPos + 2) {
+            throw new ExceptionInInitializerError("spring.datasource.url does not have port information: [" + url + "]. No port could be derived.");
+        }
+        return Integer.parseInt(url.substring(lastColonPos + 1, slashAfterPortPos));
     }
 
 }

--- a/src/main/java/nl/_42/boot/docker/postgres/DockerStartContainerCommand.java
+++ b/src/main/java/nl/_42/boot/docker/postgres/DockerStartContainerCommand.java
@@ -9,7 +9,7 @@ public class DockerStartContainerCommand extends DockerInfiniteProcessRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerStartContainerCommand.class);
 
     public DockerStartContainerCommand(DockerPostgresProperties properties, boolean imageDownloaded) {
-        super(properties.getDockerCommand(), properties, imageDownloaded);
+        super(properties.getUseDockerCommand(), properties, imageDownloaded);
 
         if (!imageDownloaded) {
             LOGGER.info("| Process will download (no visual feedback, please be patient)...");


### PR DESCRIPTION
Issue #29 by default the Docker run will make use of in-memory mounts for the application and data path in the standard Postgres Docker image. If in-memory must be disabled, it can be done in the properties. Custom paths can be passed as a list under the inMemoryMountDestinations list.

The init process has been revamped to make it less reliable on the first lazy call of getProperties().

The in-memory solution requires a dynamic number of mount mappings. The solution is to insert a template (IN_MEMORY_TEMPLATE), which is transformed into the required number of --mount mappings for Docker. IN_MEMORY_TEMPLATE is hardcoded for now. Not sure if it is sensible to make this customizable.