### PR TITLE
Docker stop command runs the wrong argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Issue [#31](https://github.com/42BV/spring-boot-docker-postgres/issues/31), **Docker stop command runs the wrong argument**; when the library notices another Docker container occupies the port that it needs to run on, a ```docker stop``` command is initiated for the port-occupying container. However, this logic was flawed, as it tried to stop a container with the same name as the container that had to be started. Fixed by using the proper container name.
 
 ## [0.7.1] - 2018-01-25
 ### Fixed

--- a/src/main/java/nl/_42/boot/docker/postgres/DockerStopContainerCommand.java
+++ b/src/main/java/nl/_42/boot/docker/postgres/DockerStopContainerCommand.java
@@ -18,7 +18,7 @@ public class DockerStopContainerCommand extends DockerFiniteProcessRunner {
 
     public DockerStopContainerCommand(DockerPostgresProperties properties) {
         super(COMMAND, properties);
-        this.containerName = properties.getContainerName();
+        this.containerName = properties.getContainerOccupyingPort();
         this.port = properties.getPort();
     }
 


### PR DESCRIPTION
Issue #31. When the library notices another Docker container occupies the port that it needs to run on, a ```docker stop``` command is initiated for the port-occupying container. However, this logic was flawed, as it tried to stop a container with the same name as the container that had to be started. Fixed by using the proper container name.