### PR TITLE
Added property: stop-if-container-exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can tweak the configuration to use for your Docker run.
 | startup-verification-text | the text that will be searched within the Docker log. If found, the Postgres container is available. Default: "PostgreSQL init process complete; ready for start up." |
 | std-out-filename          | the file to write the Docker output to. Default: "docker-std-out.log" |
 | std-err-filename          | the file to write the Docker errors to. Default: docker-std-err.log |
+| stop-if-container-exists          | stop the process if a container with 'container-name' exists. Default: false |
 | timeout                   | the timeout to apply for booting the container. Note that the value will not be used if the image has to be downloaded. Default: 300000 (5 minutes) |
 
 ## Best practices

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.2.4.RELEASE</version>
     </parent>
 
     <name>Spring Boot Docker Postgres</name>

--- a/src/main/java/nl/_42/boot/docker/postgres/DockerPostgresProperties.java
+++ b/src/main/java/nl/_42/boot/docker/postgres/DockerPostgresProperties.java
@@ -44,6 +44,8 @@ public class DockerPostgresProperties {
 
     private Map<String, String> customVariables = new HashMap<>();
 
+    private boolean stopIfContainerExists = false;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -188,6 +190,14 @@ public class DockerPostgresProperties {
         this.forceCleanAfterwards = forceCleanAfterwards;
     }
 
+    public boolean isStopIfContainerExists() {
+        return stopIfContainerExists;
+    }
+
+    public void setStopIfContainerExists(boolean stopIfContainerExists) {
+        this.stopIfContainerExists = stopIfContainerExists;
+    }
+
     public Map<String, String> getProperties() {
         Map<String,String> properties = new HashMap<>();
         properties.put("stdOutFilename", getStdOutFilename());
@@ -210,5 +220,4 @@ public class DockerPostgresProperties {
         properties.putAll(getCustomVariables());
         return properties;
     }
-
 }


### PR DESCRIPTION
If a container exists with the specified name,
property 'container-name', the process to create/stop
a new container stops.

This causes a container to be spawned at
the first launch, but it won't be killed and
no conflicts will occur when relaunching the
application.